### PR TITLE
Fix missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,6 @@ dependencies = [
     'Flask',
     'starlette',
     'certifi',
-    'kafka-python',
+    'aiokafka',
     'msgpack',
 ]


### PR DESCRIPTION
The aiokafka package is imported in aiokafka.py, so it should be a dependency. The kafka-python isn't used directly anywhere, so I removed it. It will be installed without being a direct dependency though, because aiokafka depends on it.