### PR TITLE
Refactor to support pydantic v2

### DIFF
--- a/fvhiot/models/device.py
+++ b/fvhiot/models/device.py
@@ -30,11 +30,11 @@ class Device(BaseModel):
 
 
 class PatchDeviceState(BaseModel):
-    created_at: Optional[datetime.datetime]
-    updated_at: Optional[datetime.datetime]
-    last_seen_at: Optional[datetime.datetime]
-    state: Optional[str]
-    location: Optional[str]
+    created_at: Optional[datetime.datetime] = None
+    updated_at: Optional[datetime.datetime] = None
+    last_seen_at: Optional[datetime.datetime] = None
+    state: Optional[str] = None
+    location: Optional[str] = None
 
 
 class PatchDeviceMetadata(BaseModel):
@@ -42,13 +42,13 @@ class PatchDeviceMetadata(BaseModel):
     Helper class for patching devices.
     """
 
-    device_type: Optional[str]
-    parser_module: Optional[str]
-    name: Optional[str]
-    pseudonym: Optional[str]
-    description: Optional[str]
-    state: Optional[str]
-    device_in_redis: Optional[str]
+    device_type: Optional[str] = None
+    parser_module: Optional[str] = None
+    name: Optional[str] = None
+    pseudonym: Optional[str] = None
+    description: Optional[str] = None
+    state: Optional[str] = None
+    device_in_redis: Optional[str] = None
 
 
 class PatchDevice(BaseModel):

--- a/fvhiot/models/ekoevcharging.py
+++ b/fvhiot/models/ekoevcharging.py
@@ -4,7 +4,7 @@ OCPP standard models for EKO EV charging.
 from enum import Enum
 from typing import Any, Union
 
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 
 
 class ContextEnum(str, Enum):
@@ -147,9 +147,7 @@ class StatusNotification(BaseModel):
     timestamp: str = Field(alias="packet_timestamp")  # "2021-08-16T19:21:04Z"
     vendorId: str
     vendorErrorCode: str
-
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class OCPP(BaseModel):
@@ -166,6 +164,4 @@ class OCPP(BaseModel):
     ocppStandard: str
     centralSystemResponse: Any = None
     createdAt: str = Field(alias="packet_timestamp")  # "2021-08-16T19:21:04Z"
-
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(populate_by_name=True)

--- a/fvhiot/models/mongodb.py
+++ b/fvhiot/models/mongodb.py
@@ -1,5 +1,5 @@
 import datetime
-from pydantic import BaseModel, Extra, validator
+from pydantic import field_validator, BaseModel, Extra
 
 
 class Meta(BaseModel, extra=Extra.allow):
@@ -18,7 +18,8 @@ class MongoDataline(BaseModel, extra=Extra.allow):
     meta: Meta
     time: datetime.datetime
 
-    @validator("time")
+    @field_validator("time")
+    @classmethod
     def time_must_be_aware(cls, v):
         if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
             raise ValueError("Datetime must be timezone aware, got naive datetime.")

--- a/fvhiot/models/parsed.py
+++ b/fvhiot/models/parsed.py
@@ -53,12 +53,12 @@ from typing import Any, Dict, List, Union, Tuple, Optional
 
 from fvhiot.models.device import Device
 
-from pydantic import BaseModel, validator, Extra
+from pydantic import field_validator, BaseModel, Extra
 
 
 class Column(BaseModel, extra=Extra.forbid):
     name: str
-    unit: Optional[str]
+    unit: Optional[str] = None
 
 
 class Header(BaseModel, extra=Extra.forbid):
@@ -89,7 +89,8 @@ class ParsedData(BaseModel, extra=Extra.forbid):
     header: Header
     data: List[Union[DataPointTime, DataPointStartEndTime]]
 
-    @validator("data", pre=True)
+    @field_validator("data", mode="before")
+    @classmethod
     def check_time_fields(cls, list_vals: List[dict]) -> List[dict]:
         allowed_sets = {frozenset(["time"]), frozenset(["start_time", "end_time"])}
         found_set = set()

--- a/fvhiot/models/thingpark.py
+++ b/fvhiot/models/thingpark.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import RootModel, BaseModel
 
 
 class Lrr(BaseModel):
@@ -11,8 +11,8 @@ class Lrr(BaseModel):
     LrrESP: float  # -96.212387
 
 
-class Lrrs(BaseModel):
-    __root__: Dict[str, List[Lrr]]
+class Lrrs(RootModel[Dict[str, List[Lrr]]]):
+    pass
 
 
 class Alr(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-version = "0.4.1"
+version = "1.0.0"
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
- Used bump-pydantic for most of the changes based on the [migration guide](https://docs.pydantic.dev/latest/migration/)
- Updated thingpark.py based on [documentation on the github page](https://github.com/pydantic/bump-pydantic?tab=readme-ov-file#bp006-replace-__root__-by-rootmodel), because bump-pydantic didn't change it even though it gives a warning 