### PR TITLE
fix(parsers): wrap over-long log line in sompasensecap (E501)

### DIFF
--- a/fvhiot/parsers/sompasensecap.py
+++ b/fvhiot/parsers/sompasensecap.py
@@ -39,7 +39,8 @@ def parse_s_sensecap(payload_hex: str, port: int) -> dict:
             data["battery_percentage"] = db[1]
         else:
             logging.warning(
-                f"Unknown telemetry ID {hex(_id)} encountered in payload '{payload_hex}' on port {port}. Stopping further parsing of this payload."
+                f"Unknown telemetry ID {hex(_id)} encountered in payload '{payload_hex}' on port {port}. "
+                "Stopping further parsing of this payload."
             )
             break
     return data


### PR DESCRIPTION
## What

Split a 147-char warning f-string in `fvhiot/parsers/sompasensecap.py` into two implicitly-concatenated strings so it fits the 120-char ruff limit. Message text is unchanged.

## Why

The `tests` CI job is `ruff check --output-format=github .`. The f-string introduced in #38 triggered `E501 Line too long (147 > 120)`, failing CI on **master** across all three Python versions (3.10/3.11/3.12) — and consequently on every open PR (including the Renovate onboarding PR #39).

## Verification

`uvx ruff check .` → `All checks passed!` locally; pre-commit ruff hook passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)